### PR TITLE
feat: use json5 parser for more relaxed inputs

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,4 +1,7 @@
 {
 	"extends": "./.svelte-kit/tsconfig.json",
-	"include": ["src/**/*.d.ts", "src/**/*.js", "src/**/*.svelte", "tests/util.test.js"]
+	"include": ["src/**/*.d.ts", "src/**/*.js", "src/**/*.svelte", "tests/util.test.js"],
+	"compilerOptions": {
+		"checkJs": false
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 				"@fontsource/fira-mono": "^4.5.0",
 				"@lukeed/uuid": "^2.0.0",
 				"cookie": "^0.4.1",
+				"json5": "^2.2.0",
 				"simple-icons": "^4.25.0"
 			},
 			"devDependencies": {
@@ -1521,6 +1522,20 @@
 			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
 			"dev": true
 		},
+		"node_modules/json5": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+			"integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+			"dependencies": {
+				"minimist": "^1.2.5"
+			},
+			"bin": {
+				"json5": "lib/cli.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/kleur": {
 			"version": "4.1.4",
 			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
@@ -1614,6 +1629,11 @@
 			"engines": {
 				"node": "*"
 			}
+		},
+		"node_modules/minimist": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
 		},
 		"node_modules/mri": {
 			"version": "1.2.0",
@@ -3413,6 +3433,14 @@
 			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
 			"dev": true
 		},
+		"json5": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+			"integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+			"requires": {
+				"minimist": "^1.2.5"
+			}
+		},
 		"kleur": {
 			"version": "4.1.4",
 			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
@@ -3488,6 +3516,11 @@
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
+		},
+		"minimist": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
 		},
 		"mri": {
 			"version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"@fontsource/fira-mono": "^4.5.0",
 		"@lukeed/uuid": "^2.0.0",
 		"cookie": "^0.4.1",
+		"json5": "^2.2.0",
 		"simple-icons": "^4.25.0"
 	}
 }

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -1,3 +1,4 @@
+import json5 from 'json5';
 const rootSymbol = Symbol('root');
 
 /**
@@ -23,7 +24,6 @@ function recursivelyGenerate(
 	for (const [key, value] of arr) {
 		const rootKey = isRoot ? rootSymbol : objectName;
 		if (value === null) {
-			// @ts-ignore
 			shapeObject[rootKey][key] = '?';
 		} else if (Array.isArray(value)) {
 			const uniqueTypes = value.reduce((/** @type {Set} */ acc, curr) => {
@@ -33,22 +33,18 @@ function recursivelyGenerate(
 				} else if (typeof curr === 'object') {
 					shapeObject[key] = {};
 					recursivelyGenerate(curr, key, shapeObject, false);
-					// @ts-ignore
 					type = key;
 				}
 				return acc.add(type);
 			}, new Set());
 			const types = Array.from(uniqueTypes);
 			const shape = (types.length > 1 ? `(${types.join('|')})` : types) + '[]';
-			// @ts-ignore
 			shapeObject[rootKey][key] = shape;
 		} else if (typeof value === 'object') {
 			shapeObject[key] = {};
 			recursivelyGenerate(value, key, shapeObject, false);
-			// @ts-ignore
 			shapeObject[rootKey][key] = key;
 		} else {
-			// @ts-ignore
 			shapeObject[rootKey][key] = typeof value;
 		}
 	}
@@ -65,7 +61,6 @@ export function generateJSDocForObject(obj, objName = null) {
 	const typeName = objName || 'root';
 	jsdocStatements.push(`/**\n* @typedef {object} ${typeName}`);
 	jsdocStatements.push(
-		// @ts-ignore
 		Object.entries(shapeTree[rootSymbol])
 			.map(([property, propertyType]) => `* @property {${propertyType}} ${property}`)
 			.join('\n')
@@ -94,7 +89,7 @@ export function generateJSDocOrError(obj) {
 		return null;
 	}
 	try {
-		const object = JSON.parse(obj);
+		const object = json5.parse(obj);
 		return generateJSDocForObject(object);
 	} catch (error) {
 		console.error(error);

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -88,12 +88,12 @@
 						copyText = 'Copy';
 					}, 1500);
 				}}
-				style="position: absolute; right: 0; top: 0"
+				style="position: absolute; inset-inline-end: 0; inset-block-start: 0"
 			>
 				{copyText}
 			</button>
-			<pre style="margin: 0;;">
-				<code>
+			<pre style="margin: 0;">
+				<code style="white-space: pre-line;">
 					{jsdoc}
 				</code>
 			</pre>
@@ -111,22 +111,22 @@
 	}
 
 	textarea {
-		max-width: 100%;
+		max-inline-size: 100%;
 	}
 
 	#display {
 		position: relative;
-		margin-top: 1em;
-		max-width: 100%;
+		margin-block-start: 1em;
+		max-inline-size: 100%;
 	}
 
 	h1 {
-		width: 100%;
+		inline-size: 100%;
 	}
 
 	.welcome {
 		position: relative;
-		width: 100%;
-		margin-top: 0;
+		inline-size: 100%;
+		margin-block-start: 0;
 	}
 </style>


### PR DESCRIPTION
Switch to JSON5 for parsing to support a more relaxed input schema.
Remove unnecessary ts-ignores
Fix layout of code output
Use logical css properties